### PR TITLE
Update harjoitustyo_viikko5.md

### DIFF
--- a/tehtavat/harjoitustyo_viikko5.md
+++ b/tehtavat/harjoitustyo_viikko5.md
@@ -37,7 +37,7 @@ Arvostelussa kiinnitetään huomiota seuraaviin seikkoihin
     - Käyttöliittymän rakentavan koodin ei tarvitse olla Checkstyle-tarkastelun alla
     - Jos teet projektisi jollain muulla kielellä kuin Javalla, tulee olla käytössä kielen _Checkstyleä_ vastaava työkalu, määrittele se järkevästi ja laita README-tiedostoon ohje tyylitarkastusten suorittamiselle
   - Ohjelma ei sisällä suurta määrää toisteista koodia
-    - Ohjelman dokumentaatiossa on ainakin yksi sen jotain oleellista toiminnallisuutta kuvaava sekvenssikaavio (0.5p)
+- Ohjelman dokumentaatiossa on ainakin yksi sen jotain oleellista toiminnallisuutta kuvaava sekvenssikaavio (0.5p)
   - Mallia voi ottaa [referenssisovelluksesta](https://github.com/mluukkai/OtmTodoApp/blob/master/dokumentaatio/arkkitehtuuri.md#sovelluslogiikka)
   - Lisää kaavio [edellisellä viikolla](https://github.com/mluukkai/otm-2018/blob/master/tehtavat/harjoitustyo_viikko4.md) tehtyyn dokumenttiin _arkkitehtuuri.md_ 
   - Tiedostoon _arkkitehtuuri.md_ tulee olla linkki repositorion README:stä [referenssisovelluksen](https://github.com/mluukkai/OtmTodoApp) tavoin


### PR DESCRIPTION
Fix indentation. Previously sequence diagram guide was partially under code quality section as it seems to be a section of its own.